### PR TITLE
Add branch support for remote repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Flags:
   -h, --help                help for semver-gen
   -l, --local               Use local repository
   -r, --repository string   Remote repository URL. (default "https://github.com/lukaszraczylo/simple-gql-client")
+  -b, --branch string       Remote repository URL Branch. (default "main")
   -s, --strict              Strict matching
   -u, --update              Update binary with latest
   -v, --version             Display version

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,6 +70,7 @@ type SemVer struct {
 type Setup struct {
 	RepositoryHandler   *git.Repository
 	RepositoryName      string
+	RepositoryBranch    string
 	RepositoryLocalPath string
 	LocalConfigFile     string
 	Wording             Wording
@@ -247,10 +248,12 @@ func (s *Setup) Prepare() error {
 			fmt.Println("Unable to parse repository URL", s.RepositoryName, "Error:", err.Error())
 			return err
 		}
-		s.RepositoryLocalPath = fmt.Sprintf("/tmp/semver/%s", u.Path)
+		s.RepositoryLocalPath = fmt.Sprintf("/tmp/semver/%s/%s", u.Path, s.RepositoryBranch)
 		os.RemoveAll(s.RepositoryLocalPath)
 		s.RepositoryHandler, err = git.PlainClone(s.RepositoryLocalPath, false, &git.CloneOptions{
-			URL: s.RepositoryName,
+			URL:           s.RepositoryName,
+			ReferenceName: plumbing.NewBranchReferenceName(s.RepositoryBranch),
+			SingleBranch:  true,
 			Auth: &http.BasicAuth{
 				Username: os.Getenv("GITHUB_USERNAME"),
 				Password: os.Getenv("GITHUB_TOKEN"),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,6 +41,10 @@ func (r *Setup) setupCobra() {
 	if err != nil {
 		panic(err)
 	}
+	r.RepositoryBranch, err = rootCmd.Flags().GetString("branch")
+	if err != nil {
+		panic(err)
+	}
 	r.LocalConfigFile, err = rootCmd.Flags().GetString("config")
 	if err != nil {
 		panic(err)
@@ -53,6 +57,7 @@ func (r *Setup) setupCobra() {
 
 type myParams struct {
 	varRepoName       string
+	varRepoBranch     string
 	varLocalCfg       string
 	varUseLocal       bool
 	varShowVersion    bool
@@ -69,6 +74,7 @@ func init() {
 	repo = &Setup{}
 	cobra.OnInitialize(repo.setupCobra)
 	rootCmd.PersistentFlags().StringVarP(&params.varRepoName, "repository", "r", "https://github.com/lukaszraczylo/simple-gql-client", "Remote repository URL.")
+	rootCmd.PersistentFlags().StringVarP(&params.varRepoBranch, "branch", "b", "main", "Remote repository URL Branch.")
 	rootCmd.PersistentFlags().StringVarP(&params.varLocalCfg, "config", "c", "semver.yaml", "Path to config file")
 	rootCmd.PersistentFlags().BoolVarP(&params.varUseLocal, "local", "l", false, "Use local repository")
 	rootCmd.PersistentFlags().BoolVarP(&params.varShowVersion, "version", "v", false, "Display version")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,10 @@ if [[ ! -z "$INPUT_REPOSITORY_URL" ]]; then
   FLAGS="${FLAGS} -r $INPUT_REPOSITORY_URL"
 fi
 
+if [[ ! -z "$INPUT_REPOSITORY_BRANCH" ]]; then
+  FLAGS="${FLAGS} -b $INPUT_REPOSITORY_BRANCH"
+fi
+
 if [[ ! -z "$INPUT_REPOSITORY_LOCAL" ]]; then
   FLAGS="${FLAGS} -l"
 fi


### PR DESCRIPTION
Working on "git flow" based projects some times you need to get version from branches such as "production" or "dev" etc. Therefore, the -b flag was added to select the branch in which to check out the version.