### PR TITLE
feat: auto-pin Docker image version in action.yml after release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
     paths-ignore:
       - '**.md'
       - '**/release.yaml'
-      - 'action.yml'
     branches:
       - main
 
@@ -24,3 +23,34 @@ jobs:
       rolling-release-tag: "v1"
       semver-config: "config-release.yaml"
     secrets: inherit
+
+  update-action-version:
+    needs: release
+    runs-on: ubuntu-latest
+    if: needs.release.outputs.version != ''
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update action.yml with release version
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          echo "Updating action.yml to version: ${VERSION}"
+          sed -i "s|ghcr.io/lukaszraczylo/semver-generator:[^\"]*|ghcr.io/lukaszraczylo/semver-generator:${VERSION}|" action.yml
+          echo "Updated action.yml:"
+          grep "image:" action.yml
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add action.yml
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: pin action.yml Docker image to v${{ needs.release.outputs.version }}"
+            git push
+          fi


### PR DESCRIPTION
## Problem

When users pin this action to a specific version (e.g., `@v1.15.311`), they still get
the `:latest` Docker image because `action.yml` hardcodes:

```yaml
image: "docker://ghcr.io/lukaszraczylo/semver-generator:latest"
```

This caused issues when `:latest` was updated in v1.16.1 with behavioral changes -
users who pinned the action version still received the new Docker image, leading to
unexpected version calculation results (e.g., returning `0.0.1` when HEAD is at a
tagged commit).

## Proposed Solution

Add an `update-action-version` job to the release workflow that automatically updates
`action.yml` to reference the specific Docker image version after each release.

**Changes:**
1. Remove `action.yml` from `paths-ignore` (so the automated commit doesn't re-trigger releases)
2. Add `update-action-version` job that:
   - Runs after successful release (uses the shared workflow's `version` output)
   - Updates `action.yml` with the released version tag
   - Commits and pushes the change

**After this change:**
- Each release will pin `action.yml` to the corresponding Docker image version
- Users pinning `@v1.16.5` will get Docker image `1.16.5` (not `:latest`)
- The `:latest` and `v1` tags remain available for users who want rolling updates

## Alternative Approaches

This is one possible solution. Other approaches could include:
- Using the action version input to dynamically select the Docker image
- Tagging Docker images differently
- Documenting recommended pinning practices

If considered useful and worth merging, happy to collaborate on whichever approach you prefer!

## Testing

Tested in fork: the workflow successfully creates releases and auto-updates action.yml.